### PR TITLE
Fix clang-tidy/clang-format issues and execute workflow on pull_request

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,18 +3,22 @@ name: Docker Image CI
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+      branches: [ "main" ]
 
+# We could run the test in separate jobs, but then, we would have to
+# pass artifacts around, which just increases complexity and not really
+# necessary for such a project.
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag ray_buster
+    - name: Run unit tests
+      run: docker run ray_buster bazel test --test_output=all //...
     - name: Run clang-tidy
       run: docker run ray_buster bazel build --config clang-tidy //...
-    - name: Run unit test
-      run: docker run ray_buster bazel test --test_output=all //...
-    - name: Run code formatting
-      run: docker run ray_buster format.sh
+    - name: Check code formatting
+      run: docker run ray_buster ./format-check.sh

--- a/format-check.sh
+++ b/format-check.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+clang-format --style=file --Werror --dry-run $(find -iname "*\.cc") && clang-format --style=file --Werror --dry-run $(find -iname "*\.h")

--- a/lib/trace/camera.cc
+++ b/lib/trace/camera.cc
@@ -75,9 +75,8 @@ auto Camera::ImageWidth() const -> std::size_t { return imageWidth_; }
 
 auto Camera::ImageHeight() const -> std::size_t { return imageHeight_; }
 
-auto sampleInUnitSquare(std::mt19937& randomGenerator,
-  lina::Vec3 const& unitDeltaU,
-  lina::Vec3 const& unitDeltaV) -> lina::Vec3
+auto sampleInUnitSquare(std::mt19937& randomGenerator, lina::Vec3 const& unitDeltaU, lina::Vec3 const& unitDeltaV)
+  -> lina::Vec3
 {
   auto uOffset = randomUniformDouble(randomGenerator, -0.5, 0.5);
   auto vOffset = randomUniformDouble(randomGenerator, -0.5, 0.5);

--- a/lib/trace/camera.h
+++ b/lib/trace/camera.h
@@ -23,10 +23,9 @@ public:
     double focusDistance = 1.0);
 
   // Generate a matrix of rays, with multisamplingCount number of rays per pixel
-  [[nodiscard]] auto GetSampleRayAt(std::size_t i,
-    std::size_t j,
-    std::mt19937& randomGenerator,
-    bool multiSampled = false) const -> trace::Ray;
+  [[nodiscard]] auto
+    GetSampleRayAt(std::size_t i, std::size_t j, std::mt19937& randomGenerator, bool multiSampled = false) const
+    -> trace::Ray;
 
   [[nodiscard]] auto ImageWidth() const -> std::size_t;
   [[nodiscard]] auto ImageHeight() const -> std::size_t;
@@ -47,9 +46,8 @@ private:
   lina::Vec3 lenseV_;
 };
 
-auto sampleInUnitSquare(std::mt19937& randomGenerator,
-  lina::Vec3 const& unitDeltaU,
-  lina::Vec3 const& unitDeltaV) -> lina::Vec3;
+auto sampleInUnitSquare(std::mt19937& randomGenerator, lina::Vec3 const& unitDeltaU, lina::Vec3 const& unitDeltaV)
+  -> lina::Vec3;
 
 auto sampleInUnitDisk(std::mt19937& randomGenerator,
   lina::Vec3 const& center,

--- a/lib/trace/geometry/component.cc
+++ b/lib/trace/geometry/component.cc
@@ -10,7 +10,6 @@
 #include "lib/trace/transform.h"
 
 #include <array>
-#include <cassert>
 #include <cstddef>
 #include <optional>
 #include <random>

--- a/lib/trace/geometry/cuboid.cc
+++ b/lib/trace/geometry/cuboid.cc
@@ -19,10 +19,10 @@ namespace trace {
 
 Cuboid::Cuboid()
   : Component{ Mesh{ lina::Vec3{ 0.0, 0.0, 0.0 },
-      std::vector<lina::Vec3>(8),
-      std::vector<VertexData>(),// no need
-      std::vector<std::array<std::size_t, 3>>(12),
-      std::vector<TriangleData>(12) } }
+    std::vector<lina::Vec3>(8),
+    std::vector<VertexData>(),// no need
+    std::vector<std::array<std::size_t, 3>>(12),
+    std::vector<TriangleData>(12) } }
 {
   auto unit = 1.0;
 

--- a/lib/trace/geometry/icosphere.cc
+++ b/lib/trace/geometry/icosphere.cc
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <cstddef>
 #include <format>
+#include <functional>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -30,10 +31,10 @@ namespace trace {
 // https://math.stackexchange.com/questions/2174594/co-ordinates-of-the-vertices-an-icosahedron-relative-to-its-centroid
 Icosphere::Icosphere()
   : Component{ Mesh{ lina::Vec3{ 0.0, 0.0, 0.0 },
-      std::vector<lina::Vec3>(12),
-      std::vector<VertexData>(12),
-      std::vector<std::array<std::size_t, 3>>(20),
-      std::vector<TriangleData>(20) } },
+    std::vector<lina::Vec3>(12),
+    std::vector<VertexData>(12),
+    std::vector<std::array<std::size_t, 3>>(20),
+    std::vector<TriangleData>(20) } },
     boundingBox_{
       buildCuboid(lina::Vec3{ 0.0, 0.0, 0.0 },
         2.0,

--- a/lib/trace/geometry/icosphere_test.cc
+++ b/lib/trace/geometry/icosphere_test.cc
@@ -1,3 +1,4 @@
+#include "lib/lina/vec3.h"
 #include "lib/trace/geometry/icosphere.h"
 #include "lib/trace/geometry/mesh_limits.h"
 

--- a/lib/trace/geometry/mesh.cc
+++ b/lib/trace/geometry/mesh.cc
@@ -13,9 +13,8 @@
 
 namespace trace {
 
-auto triangleCollide(Ray const& ray,
-  std::vector<TriangleData> const& trianglesData,
-  std::size_t triangleId) -> std::optional<MeshCollision>
+auto triangleCollide(Ray const& ray, std::vector<TriangleData> const& trianglesData, std::size_t triangleId)
+  -> std::optional<MeshCollision>
 {
   auto const& triangleData = trianglesData[triangleId];
 

--- a/lib/trace/geometry/mesh.h
+++ b/lib/trace/geometry/mesh.h
@@ -35,9 +35,8 @@ struct MeshCollision
   double gamma = 0.0;// weight for 0th triangle point
 };
 
-auto triangleCollide(Ray const& ray,
-  std::vector<TriangleData> const& trianglesData,
-  std::size_t triangleId) -> std::optional<MeshCollision>;
+auto triangleCollide(Ray const& ray, std::vector<TriangleData> const& trianglesData, std::size_t triangleId)
+  -> std::optional<MeshCollision>;
 
 auto meshCollide(Ray const& ray,
   std::vector<std::array<std::size_t, 3>> const& triangles,

--- a/lib/trace/geometry/plane.cc
+++ b/lib/trace/geometry/plane.cc
@@ -26,10 +26,10 @@ namespace trace {
 
 Plane::Plane()
   : Component{ Mesh{ lina::Vec3{ 0.0, 0.0, 0.0 },
-      std::vector<lina::Vec3>(4),
-      std::vector<VertexData>(),// no need
-      std::vector<std::array<std::size_t, 3>>(2),
-      std::vector<TriangleData>(2) } }
+    std::vector<lina::Vec3>(4),
+    std::vector<VertexData>(),// no need
+    std::vector<std::array<std::size_t, 3>>(2),
+    std::vector<TriangleData>(2) } }
 {
   mesh_.vertices.at(0) = lina::Vec3{ -0.5, -0.5, 0.0 };
   mesh_.vertices.at(1) = lina::Vec3{ -0.5, 0.5, 0.0 };

--- a/lib/trace/geometry/plane.h
+++ b/lib/trace/geometry/plane.h
@@ -29,8 +29,8 @@ public:
   ~Plane() override = default;
 
   [[nodiscard]] auto SamplingPDF(std::mt19937& randomGenerator, lina::Vec3 const& from) const -> PDF override;
-  friend auto
-    buildPlane(lina::Vec3 center, double width, double depth, Axis normalAxis, Orientation orientation) -> Plane;
+  friend auto buildPlane(lina::Vec3 center, double width, double depth, Axis normalAxis, Orientation orientation)
+    -> Plane;
 
 private:
   // The plane constructed plane will always have a size of 1.0 * 1.0.

--- a/lib/trace/material/dielectric.cc
+++ b/lib/trace/material/dielectric.cc
@@ -17,9 +17,8 @@ Dielectric::Dielectric(double indexOfRefraction) : indexOfRefraction_{ indexOfRe
 
 // As a rule of thumb, you know that your refraction calculations are correct, when you make dielectric
 // sphere using indexOfRefraction of 1.0, and it becomes imperceptible.
-auto Dielectric::Scatter(Ray const& ray,
-  Collision const& collision,
-  std::mt19937& randomGenerator) -> std::optional<Scattering>
+auto Dielectric::Scatter(Ray const& ray, Collision const& collision, std::mt19937& randomGenerator)
+  -> std::optional<Scattering>
 {
   // In these calculations we assume that we only ever transition between air and a given material.
   // I.e. => no compound materials will work with this.

--- a/lib/trace/material/dielectric.h
+++ b/lib/trace/material/dielectric.h
@@ -21,9 +21,8 @@ public:
 
   // As a rule of thumb, you know that your refraction calculations are correct, when you make dielectric
   // sphere using indexOfRefraction of 1.0, and it becomes imperceptible.
-  auto Scatter(Ray const& ray,
-    Collision const& collision,
-    std::mt19937& randomGenerator) -> std::optional<Scattering> override;
+  auto Scatter(Ray const& ray, Collision const& collision, std::mt19937& randomGenerator)
+    -> std::optional<Scattering> override;
 
 private:
   double indexOfRefraction_;

--- a/lib/trace/material/lambertian.cc
+++ b/lib/trace/material/lambertian.cc
@@ -15,9 +15,8 @@ namespace trace {
 
 Lambertian::Lambertian(lina::Vec3 albedo) : albedo_{ albedo } {}
 
-auto Lambertian::Scatter(Ray const& /*ray*/,
-  Collision const& collision,
-  std::mt19937& randomGenerator) -> std::optional<Scattering>
+auto Lambertian::Scatter(Ray const& /*ray*/, Collision const& collision, std::mt19937& randomGenerator)
+  -> std::optional<Scattering>
 {
   auto normal = collision.frontFace ? collision.normal : collision.normal * -1.0;
   auto adjustedCollisionPoint = collision.point + (normal * 0.00001);

--- a/lib/trace/material/lambertian.h
+++ b/lib/trace/material/lambertian.h
@@ -17,9 +17,8 @@ class Lambertian : public Material
 public:
   explicit Lambertian(lina::Vec3 albedo);
 
-  auto Scatter(Ray const& ray,
-    Collision const& collision,
-    std::mt19937& randomGenerator) -> std::optional<Scattering> override;
+  auto Scatter(Ray const& ray, Collision const& collision, std::mt19937& randomGenerator)
+    -> std::optional<Scattering> override;
 
 private:
   lina::Vec3 albedo_;

--- a/lib/trace/material/metal.cc
+++ b/lib/trace/material/metal.cc
@@ -16,9 +16,8 @@ Metal::Metal(lina::Vec3 albedo, double fuzz, std::size_t retryCount)
   : albedo_{ albedo }, fuzz_{ fuzz }, retryCount_{ retryCount }
 {}
 
-auto Metal::Scatter(Ray const& ray,
-  Collision const& collision,
-  std::mt19937& randomGenerator) -> std::optional<Scattering>
+auto Metal::Scatter(Ray const& ray, Collision const& collision, std::mt19937& randomGenerator)
+  -> std::optional<Scattering>
 {
   auto normal = collision.frontFace ? collision.normal : collision.normal * -1.0;
   auto adjustedCollisionPoint = collision.point + normal * 0.00001;

--- a/lib/trace/material/metal.h
+++ b/lib/trace/material/metal.h
@@ -24,9 +24,8 @@ public:
   // very unlikely circumstances.
   explicit Metal(lina::Vec3 albedo, double fuzz = 0.01, std::size_t retryCount = 3);
 
-  auto Scatter(Ray const& ray,
-    Collision const& collision,
-    std::mt19937& randomGenerator) -> std::optional<Scattering> override;
+  auto Scatter(Ray const& ray, Collision const& collision, std::mt19937& randomGenerator)
+    -> std::optional<Scattering> override;
 
 private:
   lina::Vec3 albedo_;

--- a/main/render/pixel_partition.cc
+++ b/main/render/pixel_partition.cc
@@ -37,8 +37,8 @@ auto ceil2(std::size_t a, std::size_t b) -> std::size_t
   return ((a - 1) / b) + 1;
 }
 
-auto closestCollision(trace::Ray const& ray,
-  std::vector<scene::Element> const& sceneElements) -> std::pair<std::optional<trace::Collision>, std::size_t>
+auto closestCollision(trace::Ray const& ray, std::vector<scene::Element> const& sceneElements)
+  -> std::pair<std::optional<trace::Collision>, std::size_t>
 {
   auto closestCollision = std::optional<trace::Collision>{};
   auto elementIndex = std::size_t{ 0 };

--- a/main/render/pixel_partition.h
+++ b/main/render/pixel_partition.h
@@ -15,8 +15,8 @@
 
 namespace render {
 
-auto closestCollision(trace::Ray const& ray,
-  std::vector<scene::Element> const& sceneElements) -> std::pair<std::optional<trace::Collision>, std::size_t>;
+auto closestCollision(trace::Ray const& ray, std::vector<scene::Element> const& sceneElements)
+  -> std::pair<std::optional<trace::Collision>, std::size_t>;
 
 auto rayColor(trace::Ray const& ray,
   std::vector<scene::Element> const& sceneElements,

--- a/main/scenes/scene_settings.cc
+++ b/main/scenes/scene_settings.cc
@@ -180,9 +180,8 @@ auto configurations() -> std::map<std::string, Configuration>
         defaultRenderSettings } },
     { "test-icosphere-emissive",
       Configuration{ "1 icosphere with an emissive material.",
-        [](scene::RenderSettings const& settings) -> scene::Composition {
-          return scene::test::icosphereEmissive(settings);
-        },
+        [](scene::RenderSettings const& settings)
+          -> scene::Composition { return scene::test::icosphereEmissive(settings); },
         defaultRenderSettings } },
     { "test-icosphere-inside-lambertian",
       Configuration{ "Inside a lambertian icosphere. The scene is lit by a plane "


### PR DESCRIPTION
I have messed up and locally installed nightly clang-tidy-19 and clang-format-19, but in the docker image used the stable version 17. This would immediatelly cause discrepancies between github actions and my local setup. This has been fixed.

Additionally separated the Github Actions into multiple jobs that could be executed in parallel after the initial build.